### PR TITLE
Switched from netcoreapp2.1 to netstandard2.0

### DIFF
--- a/fNbt/fNbt.csproj
+++ b/fNbt/fNbt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
It isn't possible to use the nuget package from either .NETFX4.6.1 or any NETStandard>=2.0 projects. Switching to NETStandard2.0 will fix this. Please don't forget to update the NuGet package 👍